### PR TITLE
fix: update version and SonarQube project key in dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 env:
-  VERSION: '1.0.0'
+  VERSION: '0.1.0'
   DOTNET_VERSION: '9.0.x'
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
         run: >
           dotnet sonarscanner begin
           /o:"wangkanai"
-          /k:"wangkanai_domain"
+          /k:"wangkanai_foundation"
           /v:${{ env.VERSION }}
           /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
           /d:sonar.host.url="https://sonarcloud.io"


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet.yml` workflow configuration to reflect changes in versioning and SonarCloud project keys.

Workflow configuration updates:

* Changed the `VERSION` environment variable from `'1.0.0'` to `'0.1.0'` to indicate an earlier release version.
* Updated the SonarCloud project key from `"wangkanai_domain"` to `"wangkanai_foundation"` in the SonarScanner step.