### PR TITLE
fix: update VersionSuffix to alpha-03 in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
    <PropertyGroup>
       <VersionPrefix>0.1.0</VersionPrefix>
-      <VersionSuffix>alpha-02</VersionSuffix>
+      <VersionSuffix>alpha-03</VersionSuffix>
       <Company>Wangkanai</Company>
       <Authors>Sarin Na Wangkanai</Authors>
       <Copyright>Copyright © 2014-2025 Sarin Na Wangkanai</Copyright>


### PR DESCRIPTION
This pull request contains a minor update to the project versioning. The version suffix has been incremented from "alpha-02" to "alpha-03" to reflect a new pre-release version.